### PR TITLE
support PEP660 pip install --editable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,19 @@ typing_extensions='~=3.7'
 tomlkit = "~=0.7"
 ppsetuptools = "==2.0.2"
 importlib_metadata = "~=4.6; python_version<='3.7'"
+editables = '~=0.2'
 
 [build-system]
 # in other build systems, this would says "requires=['setuptools', 'vulcan']" and that is all that is needed
 # to correctly install and use this tool
-requires=['setuptools', 'tomlkit', 'dataclasses', 'wheel', 'typing_extensions', 'ppsetuptools==2.0.0']
+requires=['setuptools', 
+          'tomlkit',
+          'dataclasses', 
+          'wheel',
+          'typing_extensions', 
+          'ppsetuptools==2.0.0',
+          'editables~=0.2',
+          "importlib_metadata; python_version<='3.7'"]
 build-backend="vulcan.build_backend"
 backend-path=["."]  # and this line should be removed for all other projects
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Dict, Generator
 from contextlib import contextmanager
 import os
+import sys
 
 import build
 import pytest
@@ -90,7 +91,7 @@ def test_application(tmp_path_factory: pytest.TempPathFactory) -> Path:
     tmp_path = tmp_path_factory.mktemp('build_testproject')
     (tmp_path / 'testproject').mkdir()
     (tmp_path / 'testproject/__init__.py').write_text("""\
-def test_ep() -> None:
+def test_ep():
     print("Running!")
 """)
     with (tmp_path / 'testproject/VERSION').open('w+') as f:
@@ -102,7 +103,7 @@ def test_ep() -> None:
 [project]
 name = "testproject"
 description = "an example test project for testing vulcan builds, %"
-authors = [{name="Joel Christiansen", email="joelchristiansen@optiver.com"}]
+authors = [{{name="Joel Christiansen", email="joelchristiansen@optiver.com"}}]
 keywords = [ "build", "testing" ]
 classifiers = [
     "Topic :: Software Development :: Build Tools",
@@ -126,7 +127,7 @@ packages = [ "testproject" ]
 plugins = ['example_plugin']
 
 [tool.vulcan.dependencies]
-requests = {version="~=2.25.1", extras=["security"]}
+requests = {{version="~=2.25.1", extras=["security"]}}
 
 [tool.vulcan.extras]
 test1 = ["requests", "build"]
@@ -136,7 +137,7 @@ test3 = ["requests>=2.0.0", "wheel"]
 [[tool.vulcan.shiv]]
 bin_name="testproject"
 console_script="myep"
-interpreter="/usr/bin/env python"
+interpreter="{cur_interp}"
 extra_args="-E --compile-pyc"
 
 
@@ -144,7 +145,7 @@ extra_args="-E --compile-pyc"
 requires=['setuptools', 'vulcan-py']
 build-backend="vulcan.build_backend"
 
-""")
+""".format(cur_interp=sys.executable))
 
     return tmp_path
 
@@ -154,7 +155,7 @@ def test_application_forbidden_keys(tmp_path_factory: pytest.TempPathFactory) ->
     tmp_path = tmp_path_factory.mktemp('build_testproject')
     (tmp_path / 'testproject').mkdir()
     (tmp_path / 'testproject/__init__.py').write_text("""\
-def test_ep() -> None:
+def test_ep():
     print("Running!")
 """)
     with (tmp_path / 'testproject/VERSION').open('w+') as f:
@@ -166,7 +167,7 @@ def test_ep() -> None:
 [project]
 name = "testproject"
 description = "an example test project for testing vulcan builds, %"
-authors = [{name="Joel Christiansen", email="joelchristiansen@optiver.com"}]
+authors = [{{name="Joel Christiansen", email="joelchristiansen@optiver.com"}}]
 keywords = [ "build", "testing" ]
 classifiers = [
     "Topic :: Software Development :: Build Tools",
@@ -190,7 +191,7 @@ packages = [ "testproject" ]
 plugins = ['example_plugin']
 
 [tool.vulcan.dependencies]
-requests = {version="~=2.25.1", extras=["security"]}
+requests = {{version="~=2.25.1", extras=["security"]}}
 
 [tool.vulcan.extras]
 test1 = ["requests", "build"]
@@ -200,7 +201,7 @@ test3 = ["requests>=2.0.0", "wheel"]
 [[tool.vulcan.shiv]]
 bin_name="testproject"
 console_script="myep"
-interpreter="/usr/bin/env python"
+interpreter="{cur_interp}"
 extra_args="-E --compile-pyc"
 
 
@@ -208,7 +209,7 @@ extra_args="-E --compile-pyc"
 requires=['setuptools', 'vulcan-py']
 build-backend="vulcan.build_backend"
 
-""")
+""".format(cur_interp=sys.executable))
 
     return tmp_path
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,7 +137,7 @@ test3 = ["requests>=2.0.0", "wheel"]
 [[tool.vulcan.shiv]]
 bin_name="testproject"
 console_script="myep"
-interpreter="{cur_interp}"
+interpreter='{cur_interp}'
 extra_args="-E --compile-pyc"
 
 
@@ -201,7 +201,7 @@ test3 = ["requests>=2.0.0", "wheel"]
 [[tool.vulcan.shiv]]
 bin_name="testproject"
 console_script="myep"
-interpreter="{cur_interp}"
+interpreter='{cur_interp}'
 extra_args="-E --compile-pyc"
 
 

--- a/tests/test_build_backend.py
+++ b/tests/test_build_backend.py
@@ -93,5 +93,6 @@ class TestConfig:
         assert any("; extra == 'test1'" in req for req in whl.requires_dist), "no extra dependencies found"
 
 
+@pytest.mark.xfail
 def test_editable_install(test_application: Path) -> None:
     assert False, "pip cannot yet do its part in this, see https://github.com/pypa/pip/pull/8212"

--- a/tests/test_build_backend.py
+++ b/tests/test_build_backend.py
@@ -9,7 +9,6 @@ from pkg_resources import Requirement
 from pkginfo import Wheel  # type: ignore
 from vulcan import VulcanConfigError, to_pep508
 
-
 # it is NOT expected for these to fall out of date, unless you explicitly regenerate the test lockfile
 # in tests/data
 EXPECTED_REQS = {
@@ -92,3 +91,7 @@ class TestConfig:
         whl = Wheel(test_built_application_wheel)
         assert whl.requires_dist, "No dependencies found"
         assert any("; extra == 'test1'" in req for req in whl.requires_dist), "no extra dependencies found"
+
+
+def test_editable_install(test_application: Path) -> None:
+    assert False, "pip cannot yet do its part in this, see https://github.com/pypa/pip/pull/8212"

--- a/vulcan/__init__.py
+++ b/vulcan/__init__.py
@@ -59,6 +59,7 @@ def dict_or_none(val: Any) -> Optional[Dict[str, Any]]:
 
 @dataclass
 class Vulcan:
+    name: str
     version: Optional[str]
     packages: Optional[List[str]]
     source_path: Path
@@ -75,7 +76,9 @@ class Vulcan:
     @classmethod
     def from_source(cls, source_path: Path) -> 'Vulcan':
         with open(source_path / 'pyproject.toml') as f:
-            config = tomlkit.loads(f.read())['tool']['vulcan']  # type: ignore
+            all_config = tomlkit.loads(f.read())
+            name = str(all_config['project']['name'])  # type: ignore
+            config = all_config['tool']['vulcan']  # type: ignore
             config = cast(_ContainerStub, config)
         version_file = find_version_file(source_path)
         version = version_file.read_text().strip() if version_file is not None else config.get('version')
@@ -102,7 +105,8 @@ class Vulcan:
             ))
 
         print(f"Setting version to {version}")
-        return cls(version=version, source_path=source_path, plugins=list_or_none(config.get('plugins')),
+        return cls(name=name,
+                   version=version, source_path=source_path, plugins=list_or_none(config.get('plugins')),
                    packages=list_or_none(config.get("packages")),
                    lockfile=lockfile, shiv_options=shiv_ops,
                    dependencies=install_requires,

--- a/vulcan/build_backend.py
+++ b/vulcan/build_backend.py
@@ -129,6 +129,20 @@ def get_requires_for_build_wheel(config_settings: Dict[str, str] = None) -> List
     return []
 
 
+def install_develop() -> None:
+    config = Vulcan.from_source(Path().absolute())
+
+    try:
+        virtual_env = get_virtualenv_python()
+    except RuntimeError:
+        exit('may not use vulcan develop outside of a virtualenv')
+
+    if config.configured_extras:
+        path = f'.[{",".join(config.configured_extras)}]'
+    subprocess.check_call([
+        virtual_env, '-m', 'pip', 'install', '-e', path])
+
+
 # pep660 functions
 def unpack(whl: Path) -> Path:
     with tempfile.TemporaryDirectory() as tmp:

--- a/vulcan/build_backend.py
+++ b/vulcan/build_backend.py
@@ -11,8 +11,8 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, cast
 
 import setuptools
 import tomlkit
-from editables import EditableProject
-from ppsetuptools.ppsetuptools import _parse_kwargs
+from editables import EditableProject  # type: ignore
+from ppsetuptools.ppsetuptools import _parse_kwargs  # type: ignore
 
 from vulcan import Vulcan, flatten_reqs
 from vulcan.plugins import PluginRunner

--- a/vulcan/build_backend.py
+++ b/vulcan/build_backend.py
@@ -141,7 +141,7 @@ def get_pip_version(python_callable: Path) -> Optional[Tuple[int, ...]]:
 @contextmanager
 def maybe_gen_setuppy(venv: Path, config: Vulcan) -> Generator[None, None, None]:
     pip_version = get_pip_version(venv)
-    if pip_version is None or pip_version < (999, 999, 999):  # TODO: Correct version once released
+    if pip_version is None or pip_version < (21, 3):
         print(f"pip version {pip_version} does not support editable installs for PEP517 projects,"
               " falling back to generated setup.py")
         options: Dict[str, Any] = {}

--- a/vulcan/build_backend.py
+++ b/vulcan/build_backend.py
@@ -1,4 +1,3 @@
-import json
 import os
 import shutil
 import subprocess
@@ -6,9 +5,11 @@ import sys
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, Generator, List, Optional, cast
+from typing import Any, Callable, Dict, Generator, List, Optional, cast
 
 import tomlkit
+from editables import EditableProject  # type: ignore
+from ppsetuptools.ppsetuptools import _parse_kwargs  # type: ignore
 
 from vulcan import Vulcan, flatten_reqs
 from vulcan.plugins import PluginRunner
@@ -21,7 +22,11 @@ except ImportError as e:
     raise ImportError(str(e) + '\nPlease add setuptools to [build-system] requires in pyproject.toml') from e
 
 
-from ppsetuptools.ppsetuptools import _parse_kwargs  # type: ignore
+version: Callable[[str], str]
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version
+else:
+    from importlib_metadata import version
 
 
 def _filter_nones(vals_dict: Dict[str, Optional[Any]]) -> Dict[str, Any]:
@@ -115,49 +120,6 @@ def get_virtualenv_python() -> Path:
     return Path(virtual_env, 'bin', 'python')
 
 
-# not part of PEP-517, but very useful to have
-def install_develop() -> None:
-    config = Vulcan.from_source(Path().absolute())
-    options: Dict[str, Any] = {}
-    if config.packages:
-        options['packages'] = config.packages
-    if config.version:
-        options['version'] = config.version
-
-    if config.no_lock:
-        options['install_requires'] = flatten_reqs(config.configured_dependencies)
-        options['extras_require'] = config.configured_extras
-    else:
-        options['install_requires'] = config.dependencies
-        options['extras_require'] = config.extras
-
-    try:
-        virtual_env = get_virtualenv_python()
-    except RuntimeError:
-        exit('may not use vulcan develop outside of a virtualenv')
-
-    setup = Path('setup.py')
-    if setup.exists():
-        exit('may not use vulcan develop when setup.py is present')
-    try:
-        with tempfile.NamedTemporaryFile(suffix='.json', mode="w+") as mdata_file:
-            mdata_file.write(json.dumps(options))
-            mdata_file.flush()
-            with setup.open('w+') as setup_file:
-                setup_file.write(f"""\
-from vulcan.build_backend import setup
-import json, pathlib
-setup(**json.load(pathlib.Path('{mdata_file.name}').open()))
-""")
-            path = str(Path().absolute())
-            if config.configured_extras:
-                path = f'{path}[{",".join(config.configured_extras)}]'
-            subprocess.check_call([
-                virtual_env, '-m', 'pip', 'install', '-e', path])
-    finally:
-        setup.unlink()
-
-
 # tox requires these two for some reason :(
 def get_requires_for_build_sdist(config_settings: Dict[str, str] = None) -> List[str]:
     return []
@@ -165,3 +127,53 @@ def get_requires_for_build_sdist(config_settings: Dict[str, str] = None) -> List
 
 def get_requires_for_build_wheel(config_settings: Dict[str, str] = None) -> List[str]:
     return []
+
+
+# pep660 functions
+def unpack(whl: Path) -> Path:
+    with tempfile.TemporaryDirectory() as tmp:
+        subprocess.check_output(f'wheel unpack {whl} -d {tmp}'.split())
+        unpacked = list(Path(tmp).glob('*'))
+        assert len(unpacked) == 1
+        shutil.copytree(unpacked[0], whl.parent / unpacked[0].name)
+        return whl.parent / unpacked[0].name
+
+
+def pack(unpacked_wheel: Path) -> Path:
+    with tempfile.TemporaryDirectory() as tmp:
+        subprocess.check_output(f'wheel pack {unpacked_wheel} -d {tmp}'.split())
+        packed = list(Path(tmp).glob('*.whl'))
+        assert len(packed) == 1
+        shutil.copy(packed[0], unpacked_wheel.parent)
+        return unpacked_wheel.parent / packed[0].name
+
+
+def add_requirement(unpacked_whl_dir: Path, req: str) -> None:
+    metadata = next(unpacked_whl_dir.glob('*.dist-info')) / 'METADATA'  # is mandatory
+    with metadata.open() as f:
+        metadata_lines = list(f)
+    for i, line in enumerate(metadata_lines):
+        if not (line.strip() and not line.startswith('Requires-Dist: ')):
+            # find the start of the requires-dist, or the end of the metadata keys
+            break
+    metadata_lines.insert(i, f'Requires-Dist: {req}\n')
+    metadata.write_text(''.join(metadata_lines))
+
+
+def make_editable(whl: Path) -> None:
+    config = Vulcan.from_source(Path().absolute())
+    unpacked_whl_dir = unpack(whl)
+    add_requirement(unpacked_whl_dir, f"editables (~={version('editables')})")
+    project = EditableProject(config.name, Path().absolute())
+    for name, content in project.files():
+        (unpacked_whl_dir / name).write_text(content)
+
+    assert whl == pack(unpacked_whl_dir), 'pre-wheel and post-wheel should be the same path'
+    shutil.rmtree(unpacked_whl_dir)
+
+
+def build_editable(wheel_directory: str, config_settings: Dict[str, str] = None,
+                   metadata_directory: str = None) -> str:
+    whl_path = Path(wheel_directory) / build_wheel(wheel_directory, config_settings, metadata_directory)
+    make_editable(whl_path)
+    return whl_path.name

--- a/vulcan/build_backend.py
+++ b/vulcan/build_backend.py
@@ -9,20 +9,13 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, cast
 
+import setuptools
 import tomlkit
 from editables import EditableProject  # type: ignore
 from ppsetuptools.ppsetuptools import _parse_kwargs  # type: ignore
 
 from vulcan import Vulcan, flatten_reqs
 from vulcan.plugins import PluginRunner
-
-# importing setuptools here rather than at point of use forces user to specify setuptools in their
-# [build-system][requires] section
-try:
-    import setuptools  # type: ignore
-except ImportError as e:
-    raise ImportError(str(e) + '\nPlease add setuptools to [build-system] requires in pyproject.toml') from e
-
 
 version: Callable[[str], str]
 if sys.version_info >= (3, 8):

--- a/vulcan/cli.py
+++ b/vulcan/cli.py
@@ -13,7 +13,7 @@ import tomlkit
 from pkg_resources import Requirement
 
 from vulcan import Vulcan, flatten_reqs
-from vulcan.build_backend import get_virtualenv_python
+from vulcan.build_backend import get_virtualenv_python, install_develop
 from vulcan.builder import resolve_deps
 
 version: Callable[[str], str]
@@ -153,6 +153,11 @@ def add(ctx: click.Context, config: Vulcan, req: Requirement, _lock: bool) -> No
     if not config.no_lock and _lock:
         ctx.obj = Vulcan.from_source(Path().absolute())
         ctx.invoke(lock)
+
+
+@main.command()
+def develop() -> None:
+    install_develop()
 
 
 if __name__ == '__main__':

--- a/vulcan/cli.py
+++ b/vulcan/cli.py
@@ -13,7 +13,7 @@ import tomlkit
 from pkg_resources import Requirement
 
 from vulcan import Vulcan, flatten_reqs
-from vulcan.build_backend import get_virtualenv_python, install_develop
+from vulcan.build_backend import get_virtualenv_python
 from vulcan.builder import resolve_deps
 
 version: Callable[[str], str]

--- a/vulcan/cli.py
+++ b/vulcan/cli.py
@@ -155,11 +155,5 @@ def add(ctx: click.Context, config: Vulcan, req: Requirement, _lock: bool) -> No
         ctx.invoke(lock)
 
 
-@main.command()
-def develop() -> None:
-    "Install project into current virtualenv as editable"
-    install_develop()
-
-
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
implements #14 

~~Obviously WIP, as the https://github.com/pypa/pip/pull/8212 is still WIP~~ pip 21.3 is released, with this feature.

I'm pretty happy with this, it's for sure much cleaner than the whole "dump json to tmp file, write setup.py toload that json again, pip install -e"

I did test with the lnked project and it worked exactly how I'd expect an editable install to work so that's good.