### PR TITLE
Improve `lock` behavior when venv is a different python version from vulcan

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -24,7 +25,6 @@ jobs:
     strategy:
         matrix:
             python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
-            # job: [mypy,flake8,pytest,pytest-no-cli-deps,wheel]
             os: [ubuntu-latest, windows-latest]
             # include:
             # - python-version: 3.10-dev
@@ -46,8 +46,9 @@ jobs:
     
     # Runs a single command using the runners shell
     - name: Tox
-      # env: 
-      #   TOXENV: py${{matrix.python-version}}-${{matrix.job}}
+      # Note: this list of jobs needs to be kept in-sync with tox.
+      env:
+        TOXENV: py$(echo ${{matrix.python-version}} | tr -cd '[[:digit:]]')-{mypy,flake8,pytest,pytest-no-cli-deps,wheel}
       run: |
          python -m pip install -U tox
          tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,6 @@ jobs:
     # Runs a single command using the runners shell
     - name: Tox
       # Note: this list of jobs needs to be kept in-sync with tox.
-      env:
-        
       run: |
          python -m pip install -U tox
          TOXENV="py$(echo ${{matrix.python-version}} | tr -cd '[[:digit:]]')-{mypy,flake8,pytest,pytest-no-cli-deps,wheel}" tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,10 +48,10 @@ jobs:
     - name: Tox
       # Note: this list of jobs needs to be kept in-sync with tox.
       env:
-        TOXENV: py$(echo ${{matrix.python-version}} | tr -cd '[[:digit:]]')-{mypy,flake8,pytest,pytest-no-cli-deps,wheel}
+        
       run: |
          python -m pip install -U tox
-         tox
+         TOXENV="py$(echo ${{matrix.python-version}} | tr -cd '[[:digit:]]')-{mypy,flake8,pytest,pytest-no-cli-deps,wheel}" tox
 
     - name: Build Wheel
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       # Note: this list of jobs needs to be kept in-sync with tox.
       run: |
          python -m pip install -U tox
-         TOXENV="py$(echo ${{matrix.python-version}} | tr -cd '[[:digit:]]')-{mypy,flake8,pytest,pytest-no-cli-deps,wheel}" tox
+         tox -e "py$(echo ${{matrix.python-version}} | tr -cd '[[:digit:]]')-{mypy,flake8,pytest,pytest-no-cli-deps,wheel}"
 
     - name: Build Wheel
       run: |

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -72,5 +72,5 @@ def runner() -> CliRunner:
 
 
 def successful(result: Result) -> Result:
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.stdout
     return result

--- a/vulcan/cli.py
+++ b/vulcan/cli.py
@@ -105,8 +105,8 @@ def lock(config: Vulcan) -> None:
     "Generate and update lockfile"
 
     python_version = config.python_lock_with
-    # this check does not make sense on windows as far as I can tell, there is never a "python3.6" or "python2.7" binary
-    # just "python"
+    # this check does not make sense on windows as far as I can tell,
+    # there is never a "python3.6" or "python2.7" binary just "python"
     if python_version is None and sys.platform != 'win32':
         try:
             # default to configured lock value, then current venv value if it exists, fallback to vulcan's

--- a/vulcan/cli.py
+++ b/vulcan/cli.py
@@ -18,9 +18,9 @@ from vulcan.builder import resolve_deps
 
 version: Callable[[str], str]
 if sys.version_info >= (3, 8):
-    from importlib.metadata import version, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError, version
 else:
-    from importlib_metadata import version, PackageNotFoundError
+    from importlib_metadata import PackageNotFoundError, version
 
 
 pass_vulcan = click.make_pass_decorator(Vulcan)
@@ -103,9 +103,22 @@ def build_out(config: Vulcan, outdir: Path, _lock: bool, wheel: bool, sdist: boo
 @pass_vulcan
 def lock(config: Vulcan) -> None:
     "Generate and update lockfile"
+    python_version = config.python_lock_with
+    if python_version is None:
+        try:
+            # default to configured lock value, then current venv value if it exists, fallback to vulcan's
+            # version
+            python = get_virtualenv_python()
+            python_version = subprocess.check_output(
+                [str(python),
+                    '-c',
+                    'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'],
+                encoding='utf-8').strip()
+        except RuntimeError:
+            pass
     install_requires, extras_require = resolve_deps(flatten_reqs(config.configured_dependencies),
                                                     config.configured_extras or {},
-                                                    config.python_lock_with)
+                                                    python_version)
     doc = tomlkit.document()
     doc['install_requires'] = tomlkit.array(install_requires).multiline(True)  # type: ignore
     doc['extras_require'] = {k: tomlkit.array(v).multiline(True)   # type: ignore

--- a/vulcan/cli.py
+++ b/vulcan/cli.py
@@ -103,8 +103,11 @@ def build_out(config: Vulcan, outdir: Path, _lock: bool, wheel: bool, sdist: boo
 @pass_vulcan
 def lock(config: Vulcan) -> None:
     "Generate and update lockfile"
+
     python_version = config.python_lock_with
-    if python_version is None:
+    # this check does not make sense on windows as far as I can tell, there is never a "python3.6" or "python2.7" binary
+    # just "python"
+    if python_version is None and sys.platform != 'win32':
         try:
             # default to configured lock value, then current venv value if it exists, fallback to vulcan's
             # version
@@ -114,6 +117,7 @@ def lock(config: Vulcan) -> None:
                     '-c',
                     'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'],
                 encoding='utf-8').strip()
+
         except RuntimeError:
             pass
     install_requires, extras_require = resolve_deps(flatten_reqs(config.configured_dependencies),


### PR DESCRIPTION
This improves the behavior of the `vulcan lock` command when the project
being locked is in a different venv (with a different python version) from
vulcan itself. It will now default to the current venv version rather
than vulcan's version. #27 