### PR TITLE
fix misunderstanding with specifically how editables package works

### DIFF
--- a/vulcan/build_backend.py
+++ b/vulcan/build_backend.py
@@ -234,6 +234,8 @@ def make_editable(whl: Path) -> None:
     unpacked_whl_dir = unpack(whl)
     add_requirement(unpacked_whl_dir, f"editables (~={version('editables')})")
     project = EditableProject(config.name, Path().absolute())
+    for package in (config.packages or []):
+        project.map(package, package)
     for name, content in project.files():
         (unpacked_whl_dir / name).write_text(content)
 


### PR DESCRIPTION
Wasn't clear exactly how the editable magic happens for this case. Did a bit more digging and it's clear now, the `map` controls what files end up in the .pth files in site-packages. 