### PR TITLE
add support for dev-dependencies when editable installed with new enough pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,15 @@ ppsetuptools = "==2.0.2"
 importlib_metadata = "~=4.6; python_version<='3.7'"
 editables = '~=0.2'
 
+[tool.vulcan.dev-dependencies]
+mypy=""
+flake8=""
+pytest=""
+pytest-asyncio=""
+coverage=""
+pkginfo="~=1.7"
+dataclasses="~=0.8; python_version<='3.6'"
+
 [build-system]
 # in other build systems, this would says "requires=['setuptools', 'vulcan']" and that is all that is needed
 # to correctly install and use this tool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,6 @@ warn_unused_ignores = true
 warn_unreachable = true
 strict_equality = true
 
+[[tool.mypy.overrides]]
+module = ['vulcan.isolation']
+warn_unused_ignores = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,3 @@ warn_unused_ignores = true
 warn_unreachable = true
 strict_equality = true
 
-[[tool.mypy.overrides]]
-module = ['vulcan.isolation']
-warn_unused_ignores = false

--- a/vulcan/__init__.py
+++ b/vulcan/__init__.py
@@ -100,7 +100,7 @@ class Vulcan:
         dev_dependencies: Optional[List[Requirement]] = None
         if config.get('dev-dependencies') is not None:
             dev_dependencies = [Requirement.parse(to_pep508(lib, spec))
-                                for lib, spec in config['dev-dependencies'].items()]
+                                for lib, spec in config['dev-dependencies'].items()]  # type: ignore
 
         python_lock_with = config.get('python-lock-with')
 

--- a/vulcan/__init__.py
+++ b/vulcan/__init__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union, cast
 
 import tomlkit
+from pkg_resources import Requirement
 from typing_extensions import TypedDict
 
 
@@ -67,6 +68,7 @@ class Vulcan:
     lockfile: Path
     dependencies: Optional[List[str]]
     configured_dependencies: VersionSpecs
+    dev_dependencies: Optional[List[Requirement]]
     extras: Optional[Dict[str, List[str]]]
     configured_extras: Dict[str, List[str]]
     no_lock: bool = False
@@ -95,6 +97,11 @@ class Vulcan:
                 install_requires = None
                 extras_require = None
 
+        dev_dependencies: Optional[List[Requirement]] = None
+        if config.get('dev-dependencies') is not None:
+            dev_dependencies = [Requirement.parse(to_pep508(lib, spec))
+                                for lib, spec in config['dev-dependencies'].items()]
+
         python_lock_with = config.get('python-lock-with')
 
         shiv_ops = []
@@ -116,6 +123,7 @@ class Vulcan:
                    lockfile=lockfile, shiv_options=shiv_ops,
                    dependencies=install_requires,
                    configured_dependencies=config.get('dependencies', {}),
+                   dev_dependencies=dev_dependencies,
                    extras=extras_require,
                    configured_extras=config.get('extras', {}),
                    no_lock=no_lock, python_lock_with=python_lock_with)

--- a/vulcan/build_backend.py
+++ b/vulcan/build_backend.py
@@ -250,7 +250,6 @@ def make_editable(whl: Path) -> None:
 
     assert whl == pack(unpacked_whl_dir), 'pre-wheel and post-wheel should be the same path'
     shutil.rmtree(unpacked_whl_dir)
-    shutil.copy2(whl, '/tmp')
 
 
 def build_editable(wheel_directory: str, config_settings: Dict[str, str] = None,


### PR DESCRIPTION
This implements #21 

