### PR TITLE
Also remove the actual code itself from the editable wheel, or it supersedes the .pth file

### DIFF
--- a/vulcan/build_backend.py
+++ b/vulcan/build_backend.py
@@ -238,9 +238,8 @@ def make_editable(whl: Path) -> None:
     project = EditableProject(project_name, Path().absolute())
     for package in (config.packages or []):
         project.map(package, package)
-    # removing the actual code packages because they will conflict with the .pth files, and take precendence
-    # over them
-    for package in (config.packages or []):
+        # removing the actual code packages because they will conflict with the .pth files, and take
+        # precendence over them
         shutil.rmtree(unpacked_whl_dir / package)
     for name, content in project.files():
         (unpacked_whl_dir / name).write_text(content)

--- a/vulcan/build_backend.py
+++ b/vulcan/build_backend.py
@@ -238,6 +238,10 @@ def make_editable(whl: Path) -> None:
     project = EditableProject(project_name, Path().absolute())
     for package in (config.packages or []):
         project.map(package, package)
+    # removing the actual code packages because they will conflict with the .pth files, and take precendence
+    # over them
+    for package in (config.packages or []):
+        shutil.rmtree(unpacked_whl_dir / package)
     for name, content in project.files():
         (unpacked_whl_dir / name).write_text(content)
 


### PR DESCRIPTION
Gotta say, this is a real weird way to build an editable install. But it does seem to work now.

With a wheel built without this: 

```
>>> import vulcan                              
>>> vulcan                                                            
<module 'vulcan' from '/path/to/venv//lib/python3.6/site-packages/vulcan/__init__.py'>
```

And with it:
```
>>> import vulcan
>>> vulcan
<module 'vulcan' from '/path/to/project/vulcan/vulcan/__init__.py'>
```