### PR TITLE
Ignore meaningless differences in package names

### DIFF
--- a/vulcan/builder.py
+++ b/vulcan/builder.py
@@ -8,7 +8,7 @@ from pkg_resources import Requirement
 from vulcan.isolation import VulcanEnvBuilder, create_venv
 
 
-async def build_requires(pipenv: VulcanEnvBuilder, requires: List[str]) -> Dict[str, Requirement]:
+async def build_requires(pipenv: VulcanEnvBuilder, requires: List[str]) -> Dict[Requirement, Requirement]:
     with tempfile.TemporaryDirectory() as site_packages:
         await pipenv.install(site_packages, requires)
         freeze = await pipenv.freeze(site_packages)
@@ -52,6 +52,6 @@ async def resolve_deps(install_requires: List[str], extras: Dict[str, List[str]]
                 raise res
         all_resolved = final_out_task.result()
 
-        extras_out = {k: sorted([str(all_resolved[req]) for req in v.result()]) for k, v in
-                      resolved_extras.items()}
+        extras_out = {k: sorted([str(all_resolved[req]) for req in v.result()])
+                      for k, v in resolved_extras.items()}
         return sorted([str(all_resolved[req]) for req in base_freeze.keys()]), extras_out

--- a/vulcan/isolation.py
+++ b/vulcan/isolation.py
@@ -101,7 +101,7 @@ class VulcanEnvBuilder(EnvBuilder):
             raise subprocess.CalledProcessError(returncode=proc.returncode, cmd=cmd, output=out, stderr=err)
 
     async def freeze(self, deps_dir: Union[str, bytes, 'PathLike[str]', 'PathLike[bytes]']
-                     ) -> Dict[str, Requirement]:
+                     ) -> Dict[Requirement, Requirement]:
         # list with the requirements.txt format only libraries installed in specifically this venv
         cmd = [self.context.env_exe, '-Im', 'pip', 'list', '--format=freeze', '--path', str(deps_dir)]
 
@@ -113,4 +113,4 @@ class VulcanEnvBuilder(EnvBuilder):
         if frozen.returncode != 0:
             raise subprocess.CalledProcessError(returncode=frozen.returncode, cmd=cmd, output=out, stderr=err)
         reqs = [Requirement.parse(line) for line in out.decode().split('\n') if line]
-        return {req.name: req for req in reqs}  # type: ignore
+        return {Requirement.parse(req.name): req for req in reqs}  # type: ignore


### PR DESCRIPTION
Basically, `typing-extensions` and `typing_extensions` are equivilent
for all practical purposes, but by holding the names as strings, they
were not seen as such. `freeze` will now return Dict[Requirement,
Requirement] where the first one is only the name and nothing else, and
the second has the associated version.