### PR TITLE
fix standards compliance for dynamic tags at least in convert scrip

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,11 +24,8 @@ jobs:
   build:
     strategy:
         matrix:
-            python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
+            python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
             os: [ubuntu-latest, windows-latest]
-            # include:
-            # - python-version: 3.10-dev
-            #   allowed_failure: true
 
 
     # The type of runner that the job will run on

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     strategy:
         matrix:
-            python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+            python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
             os: [ubuntu-latest, windows-latest]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ editables = '~=0.2'
 [build-system]
 # in other build systems, this would says "requires=['setuptools', 'vulcan']" and that is all that is needed
 # to correctly install and use this tool
-requires=['setuptools', 
+requires=['setuptools~=59.0', 
           'tomlkit~=0.9',
           "dataclasses~=0.8; python_version<='3.6'", 
           'wheel',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,6 +122,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
     ]
 requires-python = ">=3.6"
+dynamic = ['version', 'optional-dependencies', 'dependencies']
 
 [project.scripts]
 myep = "testproject:test_ep"

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ commands =
 skipsdist=True
 deps =
     mypy
+    types-click
     types-dataclasses
     types-setuptools
 commands =

--- a/vulcan/scripts/setuppy_to_pep621.py
+++ b/vulcan/scripts/setuppy_to_pep621.py
@@ -100,6 +100,7 @@ def convert() -> None:
     tool = cast(tomlkit.items.Table, pyproject['tool'])
     tool['vulcan'] = vulcan
     project['name'] = whl.name
+    project['dynamic'] = ['version']
     if whl.author or whl.author_email:
         project['authors'] = contributors(whl.author, whl.author_email)
     if whl.maintainer or whl.maintainer_email:
@@ -121,6 +122,7 @@ def convert() -> None:
         pass
 
     if whl.requires_dist:
+        project['dynamic'].append('dependencies')  # type: ignore[attr-defined]
         vulcan['dependencies'] = {}
         for req in whl.requires_dist:
             parsed_req = Requirement.parse(req)
@@ -132,6 +134,7 @@ def convert() -> None:
                 name = f'{name}[{",".join(parsed_req.extras)}]'
             vulcan['dependencies'][name] = str(parsed_req.specifier)  # type: ignore
     if whl.provides_extras:
+        project['dynamic'].append('optional-dependencies')  # type: ignore[attr-defined]
         extras = tomlkit.table()
         vulcan['extras'] = extras
         for extra in whl.provides_extras:


### PR DESCRIPTION
By PEP621, we should error if this key is not present and version is not provided. We do not, but setuptools does as of 61.0.0. I will upgrade to that (or newer) once support for pep621 is no longer experimental in setuptools, but in preperation for that I will also by default put these keys in new converted projects.

