### PR TITLE
Fix incorrect content-type for readme in generated wheels.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "License :: OSI Approved :: Apache Software License"
 ]
+readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.7"
-dynamic = ["dependencies", "optional-dependencies", "readme"]
+dynamic = ["dependencies", "optional-dependencies"]
 
 [project.scripts]
 vulcan="vulcan.cli:main"
@@ -24,9 +25,6 @@ example_plugin="vulcan.plugins:test_plugin"
 
 [tool.vulcan]
 no-lock = true
-
-[tool.setuptools.dynamic]
-readme = {file = ["README.md"]}
 
 [tool.setuptools.packages.find]
 include = ["vulcan*"]


### PR DESCRIPTION
https://peps.python.org/pep-0621/#readme

This feels like setuptools messing up to me. But whatever, don't really feel like digging any more.

> If the file path ends in a case-insensitive .md suffix, then tools MUST assume the content-type is text/markdown. If the file path ends in a case-insensitive .rst, then tools MUST assume the content-type is text/x-rst.