### PR TITLE
Cleanup typing extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ convert=["pkginfo~=1.7"]
 [tool.vulcan.dependencies]
 setuptools='~=63.0'
 wheel='~=0.36.2'
-typing_extensions='~=3.7'
 tomlkit = "~=0.11"
 importlib_metadata = "~=4.6; python_version<='3.7'"
 editables = '~=0.2'
@@ -64,7 +63,6 @@ requires=['setuptools~=63.0',
           'tomlkit~=0.9',
           "dataclasses~=0.8; python_version<='3.6'", 
           'wheel',
-          'typing_extensions', 
           'editables~=0.2',
           "importlib_metadata; python_version<='3.7'"]
 build-backend="vulcan.build_backend"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ types-setuptools=""
 # to correctly install and use this tool
 requires=['setuptools~=63.0',
           'tomlkit~=0.9',
-          "dataclasses~=0.8; python_version<='3.6'", 
           'wheel',
           "typing_extensions; python_version<='3.7'", 
           'editables~=0.2',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ convert=["pkginfo~=1.7"]
 [tool.vulcan.dependencies]
 setuptools='~=63.0'
 wheel='~=0.36.2'
+typing_extensions= "~=3.7; python_version<='3.7'"
 tomlkit = "~=0.11"
 importlib_metadata = "~=4.6; python_version<='3.7'"
 editables = '~=0.2'
@@ -63,6 +64,7 @@ requires=['setuptools~=63.0',
           'tomlkit~=0.9',
           "dataclasses~=0.8; python_version<='3.6'", 
           'wheel',
+          "typing_extensions; python_version<='3.7'", 
           'editables~=0.2',
           "importlib_metadata; python_version<='3.7'"]
 build-backend="vulcan.build_backend"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vulcan-py"
-version = "2.0.0"
+version = "2.0.1"
 description = "Tool for leveraging lockfiles to pin dependencies in wheels and sdists"
 authors = [{name="Joel Christiansen", email="joelchristiansen@optiver.com"}]
 urls = {github="https://github.com/optiver/vulcan-py"}

--- a/vulcan/__init__.py
+++ b/vulcan/__init__.py
@@ -7,7 +7,7 @@ import tomlkit
 import tomlkit.container
 import tomlkit.items
 from setuptools import setup
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 
 class VulcanConfigError(Exception):

--- a/vulcan/__init__.py
+++ b/vulcan/__init__.py
@@ -3,11 +3,16 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union, cast
 
+import sys
 import tomlkit
 import tomlkit.container
 import tomlkit.items
 from setuptools import setup
-from typing import TypedDict
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 
 class VulcanConfigError(Exception):


### PR DESCRIPTION
python 3.8 and above has `TypedDict` in the standard library, we dont need `typing_extensions` for versions 3.8 and above.

also no need to require `dataclasses` anymore since we dont support python 3.6.