### PR TITLE
Fix editable installs to correctly handle "where" clauses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vulcan-py"
-version = "2.0.1"
+version = "2.0.2"
 description = "Tool for leveraging lockfiles to pin dependencies in wheels and sdists"
 authors = [{name="Joel Christiansen", email="joelchristiansen@optiver.com"}]
 urls = {github="https://github.com/optiver/vulcan-py"}

--- a/vulcan/build_backend.py
+++ b/vulcan/build_backend.py
@@ -135,6 +135,13 @@ def add_requirement(unpacked_whl_dir: Path, req: str) -> None:
     metadata.write_text(''.join(metadata_lines))
 
 
+def _find_local_package(name: str) -> Path:
+    """
+    Try and find the local package being refered to for editable. Default to ./{name} if we can't find it otherwise.
+    """
+    return next(Path().rglob(f'{name}'), Path(name))
+
+
 def make_editable(whl: Path) -> None:
     unpacked_whl_dir = unpack(whl)
     add_requirement(unpacked_whl_dir, f"editables (~={version('editables')})")
@@ -149,7 +156,7 @@ def make_editable(whl: Path) -> None:
     project = EditableProject(project_name, Path().absolute())
     packages = (p for p in unpacked_whl_dir.iterdir() if not p.name.endswith('.dist-info'))
     for package in packages:
-        project.map(package.name, package.name)
+        project.map(package.name, _find_local_package(package.name))
         # removing the actual code packages because they will conflict with the .pth files, and take
         # precendence over them
         shutil.rmtree(unpacked_whl_dir / package.name)

--- a/vulcan/build_backend.py
+++ b/vulcan/build_backend.py
@@ -139,7 +139,7 @@ def _find_local_package(name: str) -> Path:
     """
     Try and find the local package being refered to for editable. Default to ./{name} if we can't find it otherwise.
     """
-    return next(Path().rglob(f'{name}'), Path(name))
+    return next(Path().rglob(name), Path(name))
 
 
 def make_editable(whl: Path) -> None:


### PR DESCRIPTION
Currently vulcan does not correctly build an editable wheel when the packages are not at the top-level. This corrects that.