### PR TITLE
LegacyVersion is removed now -- so we remove it also

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Tox
       # Note: this list of jobs needs to be kept in-sync with tox.
       run: |
-         python -m pip install -U tox pip
+         python -m pip install -U 'tox<4' pip
          tox -e "py$(echo ${{matrix.python-version}} | tr -cd '[[:digit:]]')-{mypy,flake8,test,test-no-cli-deps,wheel}"
 
     - name: Build Wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vulcan-py"
-version = "2.0.3"
+version = "2.0.4"
 description = "Tool for leveraging lockfiles to pin dependencies in wheels and sdists"
 authors = [{name="Joel Christiansen", email="joelchristiansen@optiver.com"}]
 urls = {github="https://github.com/optiver/vulcan-py"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ typing_extensions= "~=3.7; python_version<='3.7'"
 tomlkit = "~=0.11"
 importlib_metadata = "~=4.6; python_version<='3.7'"
 editables = '~=0.2'
+packaging = "~=22.0"
 
 [tool.vulcan.dev-dependencies.test]
 pytest=""

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands =
 
 [testenv:{py37,py38,py39,py310,py311}-wheel]
 commands =
-    vulcan build --wheel -o {distdir}
+    vulcan build --wheel -o {toxinidir}/.tox/dist
 
 [flake8]
 max-line-length = 120

--- a/vulcan/cli.py
+++ b/vulcan/cli.py
@@ -192,11 +192,7 @@ def add(ctx: click.Context, config: Vulcan, req: Requirement, _lock: bool) -> No
             # and parse it to a version
             spec = packaging.version.parse(str(Requirement.parse(line.strip()).specifier  # type: ignore
                                                )[2:])  # remove the == at the start
-            if isinstance(spec, packaging.version.LegacyVersion):
-                # this will raise a DeprecationWarning as well, so it will yell at user for us.
-                version = ''
-            else:
-                version = f'~={spec.major}.{spec.minor}'
+            version = f'~={spec.major}.{spec.minor}'
         except StopIteration:
             # failed to find the thing we just installed, give up.
             version = ''


### PR DESCRIPTION
Little bit ironic -- vulcan should probably lock itself, but that would break anyone who installs vulcan into each project specific venv, which is a really common workflow.