### PR TITLE
provide editable mode in backwards compatible mode for static analysis

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     strategy:
         matrix:
-            python-version: [3.7, 3.8, 3.9, "3.10"]
+            python-version: [3.8, 3.9, "3.10", "3.11"]
             os: [ubuntu-latest, windows-latest]
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ---
 
-Vulcan supports building python>=3.6. Vulcan itself may only be installed in python>=3.7. 
+Vulcan supports building python>=3.6. Vulcan itself may only be installed in python>=3.8. 
 The recommended installation is via pipx. This will save a lot of pain with respect to conflicting versions,
 as well as having multiple python versions in various projects.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,14 @@ description = "Tool for leveraging lockfiles to pin dependencies in wheels and s
 authors = [{name="Joel Christiansen", email="joelchristiansen@optiver.com"}]
 urls = {github="https://github.com/optiver/vulcan-py"}
 license = {text="Apache License Version 2.0"}
-keywords = [ "build", "tooling" ] 
+keywords = [ "build", "tooling" ]
 classifiers = [
     "Topic :: Software Development :: Build Tools",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "License :: OSI Approved :: Apache Software License"
 ]
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dynamic = ["dependencies", "optional-dependencies"]
 
 [project.scripts]
@@ -33,15 +33,13 @@ include = ["vulcan*"]
 # e.g. if these are specified, like `pip install vulcan[cli]
 [tool.vulcan.extras]
 cli=["shiv~=0.5.2","build[virtualenv]~=0.8.0", "click~=8.0"]
-convert=["pkginfo~=1.7"]
+convert=["pkginfo~=1.9"]
 
 [tool.vulcan.dependencies]
 setuptools='~=63.0'
 wheel='~=0.36.2'
-typing_extensions= "~=3.7; python_version<='3.7'"
 tomlkit = "~=0.11"
-importlib_metadata = "~=4.6; python_version<='3.7'"
-editables = '~=0.2'
+editables = '~=0.4'
 packaging = "~=22.0"
 
 [tool.vulcan.dev-dependencies.test]
@@ -53,6 +51,7 @@ coverage=""
 [tool.vulcan.dev-dependencies.static-analysis]
 flake8=""
 mypy=""
+pkginfo=""
 types-click=""
 types-dataclasses=""
 types-setuptools=""
@@ -64,14 +63,12 @@ types-setuptools=""
 requires=['setuptools~=63.0',
           'tomlkit~=0.9',
           'wheel',
-          "typing_extensions; python_version<='3.7'", 
-          'editables~=0.2',
-          "importlib_metadata; python_version<='3.7'"]
+          'editables~=0.2']
 build-backend="vulcan.build_backend"
 backend-path=["."]  # and this line should be removed for all other projects
 
 [tool.pytest.ini_options]
-filterwarnings = [ 
+filterwarnings = [
  "ignore:.*the imp module is deprecated in favour of importl.*:DeprecationWarning",
  "ignore:.*The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.*:DeprecationWarning" ]
 junit_family="xunit1"
@@ -80,7 +77,7 @@ markers = [ "cli: Tests that require full cli dependencies" ]
 asyncio_mode = 'auto'
 
 [tool.mypy]
-files = ["vulcan","tests"]
+packages = ["vulcan","tests"]
 # the following configs are the equivalent of --strict, with the exception of --no-implicit-optional
 no_implicit_optional = false
 check_untyped_defs = true
@@ -98,7 +95,3 @@ warn_unused_configs = true
 warn_unused_ignores = true
 warn_unreachable = true
 strict_equality = true
-
-[[tool.mypy.overrides]]
-module = ['vulcan.isolation']
-warn_unused_ignores = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vulcan-py"
-version = "2.0.4"
+version = "2.1.0"
 description = "Tool for leveraging lockfiles to pin dependencies in wheels and sdists"
 authors = [{name="Joel Christiansen", email="joelchristiansen@optiver.com"}]
 urls = {github="https://github.com/optiver/vulcan-py"}

--- a/tests/cli/test_builder.py
+++ b/tests/cli/test_builder.py
@@ -43,7 +43,8 @@ class TestResolveDeps:
 
     def test_resolve_deps_no_conflict(self, wheel_pkg_info: Wheel) -> None:
         reqs = [Requirement.parse(reqstring) for reqstring in wheel_pkg_info.requires_dist]
-        assert len({req.name for req in reqs}) == len({(req.name, req.specifier) for req in reqs}), 'duplicate package found in requirements'  # type: ignore # noqa: E501
+        assert len({req.name for req in reqs}) == len({(req.name, req.specifier) for req in reqs}), \
+            'duplicate package found in requirements'
 
     @pytest.mark.asyncio
     async def test_empty_reqs_empty_deps(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Dict, Generator, Iterable
 
 import pytest
-from pkginfo import Wheel  # type: ignore
+from pkginfo import Wheel
 
 import build
 

--- a/tests/test_build_backend.py
+++ b/tests/test_build_backend.py
@@ -7,11 +7,11 @@ from typing import Generator
 
 import pytest
 from pkg_resources import Requirement
-from pkginfo import Wheel  # type: ignore
+from pkginfo import Wheel
 
 from vulcan import VulcanConfigError, to_pep508
 from vulcan.build_backend import (add_requirement, build_editable,
-                                  make_editable, pack, unpack)
+                                  pack, unpack)
 
 # it is NOT expected for these to fall out of date, unless you explicitly regenerate the test lockfile
 # in tests/data
@@ -92,7 +92,7 @@ class TestConfig:
                 assert nohash.read() == b'Text!'
 
     def test_lockfile_reqs_present(self, test_application: Path, test_built_application_wheel: Path) -> None:
-        whl = Wheel(test_built_application_wheel)
+        whl = Wheel(str(test_built_application_wheel))
         assert whl.requires_dist, "No dependencies found"
         assert any("; extra == 'test1'" in req for req in whl.requires_dist), "no extra dependencies found"
 
@@ -110,7 +110,7 @@ class TestEditable:
     def test_add_requirement(self, test_built_editable_application_wheel: Path) -> None:
         unpacked = unpack(test_built_editable_application_wheel)
         add_requirement(unpacked, 'test_req (~=1.2.3)')
-        whl = Wheel(pack(unpacked))
+        whl = Wheel(str(pack(unpacked)))
         assert 'test_req (~=1.2.3)' in whl.requires_dist
 
     def test_pack_unpack_idempotent(self, test_built_editable_application_wheel: Path, tmp_path: Path
@@ -119,8 +119,8 @@ class TestEditable:
         shutil.copy(test_built_editable_application_wheel, tmp_path / 'tmp')
         repacked = pack(unpack(tmp_path / 'tmp' / test_built_editable_application_wheel.name))
 
-        new = Wheel(repacked).__dict__
+        new = Wheel(str(repacked)).__dict__
         new.pop('filename')
-        old = Wheel(test_built_editable_application_wheel).__dict__
+        old = Wheel(str(test_built_editable_application_wheel)).__dict__
         old.pop('filename')
         assert new == old

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     pkginfo
     coverage
 commands =
-    coverage run --source {toxinidir}/vulcan -m pytest -v 
+    coverage run --source {toxinidir}/vulcan -m pytest -v
 
 # Run tests using pytest
 [testenv:{py37,py38,py39,py310,py311}-test-no-cli-deps]
@@ -38,11 +38,12 @@ commands =
 skipsdist=True
 deps =
     mypy
+    pkginfo
     types-click
     types-dataclasses
     types-setuptools
 commands =
-    mypy {toxinidir}/vulcan 
+    mypy {toxinidir}/vulcan
 
 [testenv:{py37,py38,py39,py310,py311}-flake8]
 skipsdist=True
@@ -50,7 +51,7 @@ deps =
     flake8
     flake8-formatter-junit-xml
 commands =
-    flake8 {toxinidir}/vulcan 
+    flake8 {toxinidir}/vulcan
 
 [testenv:{py37,py38,py39,py310,py311}-wheel]
 commands =

--- a/vulcan/build_backend.py
+++ b/vulcan/build_backend.py
@@ -37,7 +37,7 @@ def build(outdir: str, config_settings: Dict[str, str] = None) -> str:
     # https://docs.python.org/3/distutils/apiref.html
     with PluginRunner(config):
         dist = config.setup(config_settings=config_settings)
-    rel_dist = Path(dist.dist_files[0][-1])  # type: ignore[attr-defined]
+    rel_dist = Path(dist.dist_files[0][-1])
     shutil.move(str(rel_dist), Path(outdir) / rel_dist.name)
     return rel_dist.name
 

--- a/vulcan/build_backend.py
+++ b/vulcan/build_backend.py
@@ -85,7 +85,7 @@ def get_pip_version(python_callable: Path) -> Optional[Tuple[int, ...]]:
     return tuple((int(n) for n in m.group(1).split('.')))
 
 
-def install_develop() -> None:
+def install_develop(build_isolation: bool) -> None:
     config = Vulcan.from_source(Path().absolute())
 
     try:
@@ -100,7 +100,10 @@ def install_develop() -> None:
     path = str(Path().absolute())
     if config.configured_extras:
         path = f'{path}[{",".join(config.configured_extras)}]'
-    subprocess.check_call([str(virtual_env), '-m', 'pip', 'install', '-e', path])
+    pip_call = [str(virtual_env), '-m', 'pip', 'install', '-e', path]
+    if not build_isolation:
+        pip_call.append('--no-build-isolation')
+    subprocess.check_call(pip_call)
 
 
 # pep660 functions

--- a/vulcan/build_backend.py
+++ b/vulcan/build_backend.py
@@ -160,6 +160,12 @@ def make_editable(whl: Path) -> None:
         # removing the actual code packages because they will conflict with the .pth files, and take
         # precendence over them
         shutil.rmtree(unpacked_whl_dir / package.name)
+
+    # None of the IDEs/static type tools support PEP 660
+    # As a fall-back for static analysis also provide the path in the .pth file
+    # https://github.com/microsoft/pylance-release/blob/main/TROUBLESHOOTING.md#editable-install-modules-not-found
+    project.add_to_path(project.project_dir)
+
     for name, content in project.files():
         (unpacked_whl_dir / name).write_text(content)
 

--- a/vulcan/cli.py
+++ b/vulcan/cli.py
@@ -237,8 +237,9 @@ def install_dev_dependencies(target: str = None) -> None:
 
 @main.command()
 @click.argument('dev_deps_target', required=False, type=str)
-def develop(dev_deps_target: Optional[str]) -> None:
-    install_develop()
+@click.option('--build-isolation/--no-build-isolation', '_build_isolation', default=True)
+def develop(dev_deps_target: Optional[str], _build_isolation: bool) -> None:
+    install_develop(_build_isolation)
     install_dev_dependencies(target=dev_deps_target)
 
 

--- a/vulcan/cli.py
+++ b/vulcan/cli.py
@@ -172,7 +172,7 @@ def lock(config: Vulcan) -> None:
 @click.pass_context
 def add(ctx: click.Context, config: Vulcan, req: Requirement, _lock: bool) -> None:
     "Add new top-level dependency and regenerate lockfile"
-    name: str = req.name  # type: ignore
+    name: str = req.name
     if req.extras:
         name = f'{name}[{",".join(req.extras)}]'
     try:
@@ -180,17 +180,17 @@ def add(ctx: click.Context, config: Vulcan, req: Requirement, _lock: bool) -> No
     except RuntimeError:
         exit("Must be in a virtualenv to use `vulcan add`")
     subprocess.check_call([str(venv_python), '-m', 'pip', 'install', str(req)])
-    if req.specifier:  # type: ignore
+    if req.specifier:
         # if the user gave a version spec, we blindly take that
-        version = str(req.specifier)  # type: ignore
+        version = str(req.specifier)
     else:
         # otherwise, we take a freeze to see what was actually installed
         freeze = subprocess.check_output([str(venv_python), '-m', 'pip', 'freeze'], encoding='utf-8').strip()
         try:
             # try and find the thing we just added
-            line = next(ln for ln in freeze.split('\n') if ln.startswith(req.name))  # type: ignore
+            line = next(ln for ln in freeze.split('\n') if ln.startswith(req.name))
             # and parse it to a version
-            spec = packaging.version.parse(str(Requirement.parse(line.strip()).specifier  # type: ignore
+            spec = packaging.version.parse(str(Requirement.parse(line.strip()).specifier
                                                )[2:])  # remove the == at the start
             version = f'~={spec.major}.{spec.minor}'
         except StopIteration:

--- a/vulcan/isolation.py
+++ b/vulcan/isolation.py
@@ -112,4 +112,4 @@ class VulcanEnvBuilder(EnvBuilder):
         if frozen.returncode != 0:
             raise subprocess.CalledProcessError(returncode=frozen.returncode, cmd=cmd, output=out, stderr=err)
         reqs = [Requirement.parse(line) for line in out.decode().split('\n') if line]
-        return {Requirement.parse(req.name): req for req in reqs}  # type: ignore
+        return {Requirement.parse(req.name): req for req in reqs}

--- a/vulcan/scripts/setuppy_to_pep621.py
+++ b/vulcan/scripts/setuppy_to_pep621.py
@@ -8,7 +8,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, cast
 
-import pkginfo  # type: ignore
+import pkginfo
 import tomlkit
 from pkg_resources import Requirement
 
@@ -29,7 +29,7 @@ def wheel() -> BuildData:
 
     with tempfile.TemporaryDirectory(suffix='.vulcan-migrate') as tmp:
         subprocess.run(['pip', 'wheel', '--no-deps', '-w', tmp, '.'])
-        whl = pkginfo.Wheel(next(Path(tmp).glob('*.whl')))
+        whl = pkginfo.Wheel(str(next(Path(tmp).glob('*.whl'))))
         eps: Dict[str, Dict[str, str]] = defaultdict(dict)
         with zipfile.ZipFile(whl.filename) as zf:
             dist_info = f'{whl.name.replace("-", "_")}-{whl.version}.dist-info'
@@ -106,11 +106,11 @@ def convert() -> None:
     if whl.maintainer or whl.maintainer_email:
         project['maintainers'] = contributors(whl.maintainer, whl.maintainer_email)
     if whl.classifiers:
-        project['classifiers'] = tomlkit.array(whl.classifiers).multiline(True)
+        project['classifiers'] = tomlkit.array(str(whl.classifiers)).multiline(True)
     if whl.summary:
         project['description'] = whl.summary
     if whl.keywords:
-        project['keywords'] = tomlkit.array(whl.keywords.split(',')).multiline(True)
+        project['keywords'] = tomlkit.array(str(whl.keywords.split(','))).multiline(True)
     if whl.license:
         project['license'] = whl.license
     if whl.project_urls:
@@ -129,7 +129,7 @@ def convert() -> None:
             if '; extra == "' in str(parsed_req):
                 # extra, swing back to this
                 continue
-            name = parsed_req.name  # type: ignore
+            name = parsed_req.name
             if parsed_req.extras:
                 name = f'{name}[{",".join(parsed_req.extras)}]'
             vulcan['dependencies'][name] = str(parsed_req.specifier)  # type: ignore


### PR DESCRIPTION
Previously the pth file would be:
```
import _editable_impl_component_schedules
```

Now it will generate a pth file like:

```
import _editable_impl_component_schedules
/home/florisvannee/workspace/component_schedules
```

This is not ideal either, as this will not have 100% identical behavior in all cases. However, it is similar at least similar to "old" setup.py behavior before PEP 660.
Without this, no IDE even recognizes imports of the editable module. Code completion doesn't work, etc.
With this, I think it still won't support complex cases where different packages hide in subdirectories. That is, the code will still work at run-time, but the IDEs might still not properly support it. However, at least this covers the most common cases.

An alternative that some other build tools provide is to hide this switch to old behavior in a flag like 'legacy-mode'. I'd rather just support it by default like this, as imo editable installs without any static analysis working on them are totally useless.

I don't know if this change might have other implications though. Interested to hear input.

So this was at first a one-line PR, but whole bunch of mypy errors were occurring. This leads to the second commit with more changes. All should be trivial, except that some mypy stuff required pkginfo with type info that didn't work on Python 3.7. Therefore I'm dropping support for this.